### PR TITLE
added interrupt latency code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,10 @@ GDB_RUN_CMDS_irq_latency += -ex "set mem inaccessible-by-default off"
 GDB_RUN_CMDS_irq_latency += -ex "set remotetimeout 250"
 GDB_RUN_CMDS_irq_latency += -ex "set arch riscv:rv32"
 GDB_RUN_CMDS_irq_latency += -ex "load"
+# OpenOCD will execute Fence + Fence.i when resuming
+# the processor from the debug mode. This is needed for proper operation
+# of SW breakpoints with ICACHE
 GDB_RUN_CMDS_irq_latency += -ex "si"
-GDB_RUN_CMDS_irq_latency += -ex "b int-latency.c:189"
 GDB_RUN_CMDS_irq_latency += -ex "c"
 GDB_RUN_CMDS_irq_latency += -ex 'printf "\n" '
 GDB_RUN_CMDS_irq_latency += -ex 'printf "\n" '

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ else ifeq ($(BOARD),N25)
 else ifeq ($(BOARD),X300)
 	RISCV_ARCH := rv32imac
 	RISCV_ABI := ilp32
+else ifeq ($(BOARD),EH1)
+	RISCV_ARCH := rv32imc
+	RISCV_ABI := ilp32
 else
 	$(error Unsupported board $(BOARD))
 endif
@@ -48,16 +51,28 @@ export BSP_BASE
 export BSP_DIR
 
 #############################################################
+# Rules for building single benchmark
+#############################################################
+.PHONY: ctx_switch 
+ctx_switch: 
+	$(MAKE) -C ctx_switch
+
+.PHONY: irq_latency 
+irq_latency: 
+	$(MAKE) -C irq_latency
+
+#############################################################
 # Rules for building all benchmarks
 #############################################################
-
 .PHONY: all 
 all: 
 	$(MAKE) -C ctx_switch
+	$(MAKE) -C irq_latency
 
 .PHONY: clean
 clean: 
 	$(MAKE) -C ctx_switch clean
+	$(MAKE) -C irq_latency clean
 
 
 #############################################################
@@ -70,7 +85,7 @@ ifndef OPENOCD
 $(error OPENOCD not set)
 endif
 
-OPENOCD := $(abspath $(OPENOCD))/bin/openocd
+OPENOCD := $(abspath $(OPENOCD))/openocd
 
 OPENOCDCFG ?= bsp/$(BOARD)/openocd.cfg
 OPENOCDARGS += -f $(OPENOCDCFG)
@@ -93,22 +108,54 @@ load:
 	$(GDB) $(TEST)/$(TEST).hex $(GDB_LOAD_ARGS) $(GDB_LOAD_CMDS)
 
 #############################################################
-# Run benchmark
+# GDB args: ctx_switch benchmark
 #############################################################
 
-GDB_RUN_ARGS ?= --batch
-GDB_RUN_CMDS += -ex "target extended-remote localhost:$(GDB_PORT)"
-GDB_RUN_CMDS += -ex "shell clear"
-GDB_RUN_CMDS += -ex 'printf "> emBench - running ...\n" '
-GDB_RUN_CMDS += -ex "jump start"
-GDB_RUN_CMDS += -ex 'printf "> emBench - complete\n" '
-GDB_RUN_CMDS += -ex 'printf "> emBench - result : " '
-GDB_RUN_CMDS += -ex 'info registers $$mhpmcounter4'
-GDB_RUN_CMDS += -ex "monitor shutdown"
-GDB_RUN_CMDS += -ex "quit"
+GDB_RUN_ARGS_ctx_switch ?= --batch
+GDB_RUN_CMDS_ctx_switch += -ex "target extended-remote localhost:$(GDB_PORT)"
+GDB_RUN_CMDS_ctx_switch += -ex "shell clear"
+GDB_RUN_CMDS_ctx_switch += -ex 'printf "> emBench - running ...\n" '
+GDB_RUN_CMDS_ctx_switch += -ex "jump start"
+GDB_RUN_CMDS_ctx_switch += -ex 'printf "> emBench - complete\n" '
+GDB_RUN_CMDS_ctx_switch += -ex 'printf "> emBench - result : " '
+GDB_RUN_CMDS_ctx_switch += -ex 'info registers $$mhpmcounter4'
+GDB_RUN_CMDS_ctx_switch += -ex "monitor shutdown"
+GDB_RUN_CMDS_ctx_switch += -ex "quit"
+
+#############################################################
+# GDB args: irq_latency benchmark
+#############################################################
+
+GDB_RUN_ARGS_irq_latency ?= 
+GDB_RUN_CMDS_irq_latency += -ex "target remote localhost:$(GDB_PORT)"
+GDB_RUN_CMDS_irq_latency += -ex "set mem inaccessible-by-default off"
+GDB_RUN_CMDS_irq_latency += -ex "set remotetimeout 250"
+GDB_RUN_CMDS_irq_latency += -ex "set arch riscv:rv32"
+GDB_RUN_CMDS_irq_latency += -ex "load"
+GDB_RUN_CMDS_irq_latency += -ex "si"
+GDB_RUN_CMDS_irq_latency += -ex "b int-latency.c:189"
+GDB_RUN_CMDS_irq_latency += -ex "c"
+GDB_RUN_CMDS_irq_latency += -ex 'printf "\n" '
+GDB_RUN_CMDS_irq_latency += -ex 'printf "\n" '
+GDB_RUN_CMDS_irq_latency += -ex 'printf "> irq_latency: cycles from interrupt -> vect entry ...\n" '
+GDB_RUN_CMDS_irq_latency += -ex "p cycles_to_vect_entry"
+GDB_RUN_CMDS_irq_latency += -ex 'printf "> irq_latency: cycles from interrupt -> trap entry ...\n" '
+GDB_RUN_CMDS_irq_latency += -ex "p cycles_to_trap_entry"
+GDB_RUN_CMDS_irq_latency += -ex 'printf "> irq_latency: cycles from interrupt -> isr entry (vector mode) ...\n" '
+GDB_RUN_CMDS_irq_latency += -ex "p cycles_to_isr_vect_mode"
+GDB_RUN_CMDS_irq_latency += -ex 'printf "> irq_latency: cycles from interrupt -> isr entry (trap mode)  ...\n" '
+GDB_RUN_CMDS_irq_latency += -ex "p cycles_to_isr_trap_mode"
+GDB_RUN_CMDS_irq_latency += -ex 'printf "> irq_latency: Done ...\n" '
+GDB_RUN_CMDS_irq_latency += -ex "monitor shutdown"
+GDB_RUN_CMDS_irq_latency += -ex "quit"
+
+#############################################################
+# Run benchmark
+#############################################################
+#	$(OPENOCD) $(OPENOCDARGS) 2>/dev/null & \
 
 .PHONY: run
 run:
-	$(OPENOCD) $(OPENOCDARGS) 2>/dev/null & \
-	$(GDB) $(TEST)/$(TEST).elf $(GDB_RUN_ARGS) $(GDB_RUN_CMDS)
+	$(OPENOCD) $(OPENOCDARGS) & \
+	$(GDB) $(TEST)/$(TEST).elf $(GDB_RUN_ARGS_$(TEST)) $(GDB_RUN_CMDS_$(TEST))
 	

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Supported hardware
 * E31 - SiFive RV32IMACU
 
    Coming soon ...
+
+* EH1 - WDC RV32IMC
+
+   https://github.com/chipsalliance/Cores-SweRVolf

--- a/bsp/EH1/link.lds
+++ b/bsp/EH1/link.lds
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2019 Western Digital Corporation or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/ 
+
+/*
+ Linker script
+*/
+
+OUTPUT_ARCH( "riscv" )
+
+ENTRY( _start )
+
+__comrv_overlay_storage_size = DEFINED(__comrv_overlay_storage_size) ? __comrv_overlay_storage_size : 0;
+
+MEMORY
+{
+  ram  (wxa!ri) : ORIGIN = 0x00000000, LENGTH = 64M
+  ram2 (wxa!ri) : ORIGIN = 0x04000000, LENGTH = 64M
+  dccm (wxa!ri) : ORIGIN = 0xf0040000, LENGTH = 64K
+  ovl           : ORIGIN = 0xE0000000, LENGTH = __comrv_overlay_storage_size
+}
+
+PHDRS
+{
+  rom_load PT_LOAD;
+  ram_init PT_LOAD;
+  ram_load PT_LOAD;
+  ovl PT_NULL;
+}
+
+
+/*----------------------------------------------------------------------*/
+/* Sections                            */
+/*----------------------------------------------------------------------*/
+
+SECTIONS
+{
+  __stack_size = DEFINED(__stack_size) ? __stack_size : 4K;
+  __comrv_cache_size = DEFINED(__comrv_cache_size) ? __comrv_cache_size : 0;
+  __comrv_cache_alignment_size = DEFINED(__comrv_cache_alignment_size) ? __comrv_cache_alignment_size : 0;
+
+  .text.init :
+  {
+    *(.text.init)
+    . = ALIGN(8);
+  } > ram : ram_load
+
+  .text :
+  {
+    *(.text.unlikely .text.unlikely.*)
+    *(.text.startup .text.startup.*)
+    *(.text .text.*)
+    *(COMRV_TEXT_SEC)
+    *(COMRV_TEXT_ASM)
+    *(.gnu.linkonce.t.*)
+    . = ALIGN(4);
+  } >ram : ram_load
+
+
+  .rodata :
+  {
+    *(.rdata)
+    *(.rodata .rodata.*)
+    *(.gnu.linkonce.r.*)
+    KEEP(*(COMRV_RODATA_SEC))
+    . = ALIGN(4);
+  } > ram : ram_load
+
+  /* this is a placeholder for comrv overlay groups.
+     after linking, we'll use objcopy utility and change the
+     address of .ovlgrpdata to this address */ 
+  .reserved_ovl : ALIGN(4)
+  {
+    _OVERLAY_STORAGE_START_ADDRESS_ = .;
+    . = LENGTH(ovl);
+  } > ram : ram_load
+
+  
+  .lalign : 
+  {
+    . = ALIGN(4);
+    PROVIDE( _data_lma = . );
+  } > ram : ram_load
+  
+  .dalign :
+  {
+    . = ALIGN(4);
+    PROVIDE( _data = . );
+  } > ram : ram_load
+  
+  
+  .data :
+  {
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    . += 10; /* fix for linker false error message */
+    . = ALIGN(8); 
+  } > ram : ram_load
+
+  COMRV_DATA_SEC : ALIGN(16)
+  {
+  
+  }  > ram2 : ram_load
+
+  PSP_DATA_SEC : ALIGN(16)
+  {
+  
+  }  > ram2 : ram_load
+
+  .sdata :
+  {
+    . = ALIGN(8);
+    __global_pointer$ = . + 0x800;
+    *(.sdata .sdata.*)
+    *(.gnu.linkonce.s.*)
+    . = ALIGN(8);
+    *(.srodata .srodata.*)
+   . = ALIGN(8);
+  } > ram : ram_load
+
+
+  
+  . = ALIGN(4);
+  PROVIDE( _edata = . );
+  PROVIDE( edata = . );
+
+  PROVIDE( _fbss = . );
+  PROVIDE( __bss_start = . );
+  
+  .bss :
+  {
+    *(.sbss .sbss.* .gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.bss)
+    . = ALIGN(8);
+  } >ram : ram_load
+
+  _end = .;
+
+  .stack :
+  {
+    _heap_end = .;
+    . = . + __stack_size;
+    _sp = .;
+  } > ram : ram_load
+  
+  
+  /* this area is used for loading and executing the comrv 
+     overlay groups */
+  .overlay_sec ALIGN(__comrv_cache_alignment_size) :
+  {
+    __OVERLAY_CACHE_START__ = . ;
+    . = . + __comrv_cache_size; 
+    __OVERLAY_CACHE_END__ = . ;
+  } > ram : ram_load
+
+  /* this is the location of all comrv overlay groups.
+     after linking, we'll use objcopy utility and copy
+     it to the .reserved_ovl section. we do this
+     to make sure there is no address dependency after linking */ 
+  .ovlgrps (OVERLAY) : 
+  {
+    OVERLAY_START_OF_OVERLAYS = .;
+    *(.ovlinput.*)
+    OVERLAY_END_OF_OVERLAYS = .;
+  } >ovl AT>ovl :ovl
+}

--- a/bsp/EH1/openocd.cfg
+++ b/bsp/EH1/openocd.cfg
@@ -1,0 +1,109 @@
+#interface ftdi
+adapter driver ftdi
+ftdi_device_desc "Digilent USB Device"
+ftdi_vid_pid 0x0403 0x6010
+ftdi_channel 0
+ftdi_layout_init 0x0088 0x008b
+
+#[OS] reset_config none
+#ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+
+
+
+#adapter_khz 15000
+adapter speed 5000
+
+transport select jtag
+
+set _CHIPNAME riscv
+
+jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x13631093 -ignore-version
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+
+#riscv set_reset_timeout_sec 1
+#riscv set_command_timeout_sec 1
+
+# So prefer system bus access (SBA).
+riscv set_prefer_sba on
+
+# Because JTAG in SweRVolf is tunneled through BSCAN, 
+# re-define the IR codes for RISC-V debug registers.
+riscv set_ir idcode 0x9
+riscv set_ir dmi 0x22
+riscv set_ir dtmcs 0x23
+
+
+
+
+#riscv set_ir dtmcs 0x2023
+#sleep 1000
+#riscv set_ir dtmcs 0x30023
+
+
+#$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+
+
+
+# Codasip change start --------------------------------------------------
+
+# Part 3: Solution for SW breakpoints with ICACHE enabled
+
+# Expose custom SweRV CSR 
+# CSR_MRAC           0x7C0          /* Region access control  */
+# CSR_MCPC           0x7C2          /* Core pause control  */
+# CSR_DMST           0x7C4          /* Memory synchronization trigger (debug mode only)  */
+# CSR_MPMC           0x7C6          /* Power management control  */
+# CSR_DICAWICS       0x7C8          /* I-cache array/way/index selection (debug mode only)  */
+# CSR_DICAD0         0x7C9          /* I-cache array data 0 (debug mode only)  */
+# CSR_DICAD1         0x7CA          /* I-cache array data 1 (debug mode only)  */
+# CSR_DICAGO         0x7CB          /* I-cache array go (debug mode only)  */
+# CSR_MGPMC          0x7D0          /* Group performance monitor control  */
+# CSR_MICECT         0x7F0          /* I-cache error counter/threshold */
+# CSR_MICCMECT       0x7F1          /* ICCM correctable error counter/threshold  */
+# CSR_MDCCMECT       0x7F2          /* DCCM correctable error counter/threshold  */
+# CSR_MCGC           0x7F8          /* Clock gating control  */
+# CSR_MFDC           0x7F9          /* Feature disable control  */
+# CSR_MDEAU          0xBC0          /* D-Bus error address unlock  */
+# CSR_MDSEAC         0xFC0          /* D-bus first error address capture  */
+# CSR_MEIPT          0xBC9          /* External interrupts priority threshold  */
+# CSR_MEIVT          0xBC8          /* External interrupts vector table  */
+# CSR_MEIHAP         0xFC8          /* External interrupts handler address pointer  */
+# CSR_MEICPCT        0xBCA          /* External interrupts claim ID / priority level capture trigger  */
+# CSR_MEICIDPL       0xBCB          /* External interrupts claim IDs priority level  */
+# CSR_MEICURPL       0xBCC          /* External interrupts current priority level  */
+# ----------------0x7C0-0x7cB | 0x7D0 | 0x7F0-0x7F2 | 0x7F8-0x7F9 |0xBC0 | 0xFC0 | 0xBC8-0xBC9 | 0xFC8 | 0xBCA-0xBCC
+riscv expose_csrs 1984-1995,2000,2032-2034,2040-2041,3008,4032,3016-3017,4040,3018-3021
+
+
+proc swerv_eh1_execute_fence {} {
+    # Execute fence + fence.i via "dmst" register
+    reg csr1988 0x3
+}
+
+# Configure events hooks in OpenOCD to execute Fence + Fence.i when resuming
+# the processor from the debug mode. This is needed for proper operation
+# of SW breakpoints when ICACHE in SweRV is enabled:
+
+$_TARGETNAME configure -event resume-start {
+    swerv_eh1_execute_fence
+}
+
+$_TARGETNAME configure -event step-start {
+    # Note: As of Q2/2020, "step-start" event is a new feature in OpenOCD.
+    # A very recent version of OpenOCD is needed (upstream commit 25efc150 or newer).
+    swerv_eh1_execute_fence
+}
+
+# Codasip change end --------------------------------------------------
+
+
+init
+
+#riscv dmi_read 0x301
+
+
+
+#halt

--- a/bsp/EH1/startup.S
+++ b/bsp/EH1/startup.S
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2019 Western Digital Corporation or its affiliates.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+#Simple start up file for the reference design
+
+#ifdef D_LLVM_COMRV
+/* disable warning for reserved registers use - we are using comrv
+   reserved register and don't want to see these warnings. */
+.option nowarnreservedreg
+#endif /* __clang__ */
+
+  .section ".text.init"
+  .global _start
+  .type   _start, @function
+
+
+
+
+_start:
+  #clear minstret
+  csrw minstret, zero
+  csrw minstreth, zero
+
+  #clear registers
+  li  x1, 0
+  li  x2, 0
+  li  x3, 0
+  li  x4, 0
+  li  x5, 0
+  li  x6, 0
+  li  x7, 0
+  li  x8, 0
+  li  x9, 0
+  li  x10,0
+  li  x11,0
+  li  x12,0
+  li  x13,0
+  li  x14,0
+  li  x15,0
+  li  x16,0
+  li  x17,0
+  li  x18,0
+  li  x19,0
+  li  x20,0
+  li  x21,0
+  li  x22,0
+  li  x23,0
+  li  x24,0
+  li  x25,0
+  li  x26,0
+  li  x27,0
+  li  x28,0
+  li  x29,0
+  li  x30,0
+  li  x31,0
+
+
+    #cache configuration
+  li t1, 0x55555555
+  csrw 0x7c0, t1
+  fence.i
+  # initialize global pointer
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+  la sp, _sp
+
+/* [OS] we dont have this memory to load from ----
+  // Load data section
+  la a0, _data_lma
+  la a1, _data
+  la a2, _edata
+
+
+  bgeu a1, a2, 2f
+1:
+  lw t0, (a0)
+  sw t0, (a1)
+  addi a0, a0, 4
+  addi a1, a1, 4
+  bltu a1, a2, 1b
+2:
+*/
+  /* Clear bss section */
+  la a0, __bss_start
+  la a1, _end
+  bgeu a0, a1, 2f
+1:
+  sw zero, (a0)
+  addi a0, a0, 4
+  bltu a0, a1, 1b
+2:
+
+  /* Call global constructors *//*
+  la a0, __libc_fini_array
+  call atexit */
+  call __libc_init_array
+
+
+#  #hart id
+#OS  csrr a0, mhartid
+#OS  li   a1, 1
+#OS 1:  bgeu a0, a1, 1b
+    # argc = argv = 0 t0
+    li a0, 0
+    li a1, 0
+
+    call benchmark
+    
+    #[OS]: no need for exit, just endless loop here.....was: tail atexit
+  # loop here
+ 2:  j 2b

--- a/irq_latency/Makefile
+++ b/irq_latency/Makefile
@@ -1,0 +1,47 @@
+
+TARGET := irq_latency.elf
+LINKER_SCRIPT := $(BSP_DIR)/link.lds
+
+.PHONY: all
+all: $(TARGET)
+
+ASM_SRCS += $(BSP_DIR)/startup.S
+ASM_SRCS += source/psp-int-rv.S
+C_SRCS += source/bsp-rv-swerv-olof-eh1.c
+C_SRCS += source/int-latency.c
+
+INCLUDES =
+
+ASM_OBJS := $(ASM_SRCS:.S=.o)
+C_OBJS := $(C_SRCS:.c=.o)
+
+CDEFINES += -DD_CYCLES -DD_64_BIT_CYCLES
+
+CFLAGS += -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -mcmodel=medlow -Os -g3 -ffunction-sections -fdata-sections -Wall
+
+LDFLAGS += -T $(LINKER_SCRIPT) -nostartfiles
+LINK_OBJS += $(ASM_OBJS) $(C_OBJS)
+LINK_DEPS += $(LINKER_SCRIPT)
+CLEAN_OBJS += $(TARGET) $(LINK_OBJS)
+
+HEX = $(subst .elf,.hex,$(TARGET))
+LST = $(subst .elf,.lst,$(TARGET))
+CLEAN_OBJS += $(HEX)
+CLEAN_OBJS += $(LST) 
+
+$(TARGET): $(LINK_OBJS) $(LINK_DEPS)
+	$(CC) $(CDEFINES) $(CFLAGS) $(INCLUDES) $(LINK_OBJS) -o $@ $(LDFLAGS)
+	$(OBJDUMP) --all-headers --demangle --disassemble --file-headers --wide -DS $(TARGET) > $(LST)
+
+$(ASM_OBJS): %.o: %.S $(HEADERS)
+	$(CC) $(CDEFINES) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+$(C_OBJS): %.o: %.c $(HEADERS)
+	$(CC) $(CDEFINES) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f $(CLEAN_OBJS) 
+
+
+

--- a/irq_latency/design/rv-int-latency.md
+++ b/irq_latency/design/rv-int-latency.md
@@ -1,206 +1,135 @@
 # RiscV interrupt latency benchmark
+
 ## Interrupt Latency Measurement Concept
+
 ### Assumption
 The provided core is connected to at least one  external interrupt source that can be triggered by a running firmware.
+
 ### Measurement
+
 Interrupt latency measurement is done by using the cycles counter (`mcycle` and `mcycleh`).
-
-Start measurement point: when all interrupts are disabled (`mstatus`) and the configured external interrupt already occurred.
-
+1. Measure from interrupt trigger to vector/trap entry
+Start measurement point: when interrupts are enabled (`mstatus`) and the configured external interrupt enabled.
 End measurement point depends on `mtvec` mode:
 - Trap mode: first 2 instructions read `mcycle` and `mcycleh` counters
 - Vector mode: first 2 instructions read `mcycle` and `mcycleh` counters
+2. Measure from interrupt trigger to isr (in both vector/trap mode)
+Start measurement point: when interrupts are enabled (`mstatus`) and the configured external interrupt enabled.
+End measurement point: isr entry
 
 Read `mcycle` and `mcycleh` counters is done to core registers `t5` and `t6` (it is assumed they are not used in the said flow)
 
 ### Benchmark flow
-1. Measure the amount of cycles cost of overhead code (how much does it cost to measure): 
-    - Reading `mcycle` and `mcycleh` csrs 
-    - Setting a bit in `mstatus` csr
+1. Measure the amount of cycles cost of overhead code (how much does it cost to measure)
 2. Configure and enable a specific external interrupt - this external interrupt source is used to perform the latency measurements.
-3. Enable external interrupts in `mie`
-4. Execute the loop in step [6] when `mtvec` is set to trap mode
-5. Execute the loop in step [6] when `mtvec` is set to vector mode
-6. Loop x times:
-    - Disable interrupts (`mstatus`)
-    - Trigger the external interrupt
-    - Start measure point
-    - Enable interrupts (`mstatus`)
-    - At this point we have the amount of cycles cost for current interrupt so we reduce from it the overhead cycles measured  in step [1]
-    - Accumulate total cycles
-7. Calculate the average cycles count for trap mode
-8. Calculate the average cycles count for vector mode
+3. Enable external interrupts
+4. measure cycles from interrupt trigger to vector entry
+5. measure cycles from interrupt trigger to trap entry
+6. measure cycles from interrupt trigger to isr entry (vector mode)
+7. measure cycles from interrupt trigger to isr entry (trap mode)
+
 ## BSP
+
 The following functions implementation shall be provided per BSP:
+
 - void bsp_init(void) -> BSP specific initialization function.
 - void bsp_enble_external_interrupt(void) -> Set and enable a specific external interrupt
 - void bsp_trigger_external_interrupt(void) -> Trigger the configured external interrupt
 - void bsp_clear_external_interrupt_indication(void) -> Clear the external interrupt indication - called from the interrupt handler
+- extern void bsp_enable_interrupts(void) -> system disable interrupts
+- extern void bsp_disable_interrupts(void) -> system enable interrupts
+- extern void bsp_trigger_external_interrupt_measure_cycles(volatile cycles_t* p_cycles) -> measure the cost in cycles of trigegrring the external interrupt   
+- extern void bsp_set_interrupts_handler(void *p_ints_handler, unsigned int is_vector) -> set interrupt vector/trap address
 
 ## Benchmark main function
 ```
 static int __attribute__ ((noinline))
 benchmark_body (int rpt)
 {
-  unsigned int loop_count, loc_vec_cnt = 0, loc_trp_cnt = 0;
-
-  /* read mcycle and mcycleh */
-  M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
-  /* we want to measure number of cycles for write csr and read csr */
-  M_SET_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
-  M_READ_CYCLE_COUNTER_CSR(tmp);
-  /* read mcycle */
-  M_READ_CYCLE_COUNTER_CSR(cycles_overhead);
-  /* calculate cycles overhead */
-  cycles_overhead -= g_num_of_cycles_start;
-
   /* initialize and enable a specific external interrupt */
   bsp_enble_external_interrupt();
 
-  for (loop_count = 0 ; loop_count < D_LOOP_COUNT ; loop_count++)
-  {
-      /*
-       * measure number of cpu cycles in vector mode
-       */
-      /* disable interrupts */
-      M_CLEAR_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
-      /* enable external interrupts in mie */
-      M_SET_CSR_BITS(mie, D_MIE_MEIE_MASK);
-      /* init mtvec - vector mode */
-      M_WRITE_CSR(mtvec, (unsigned int)psp_vect_table | 1);
-      /* trigger a specific external interrupt */
-      bsp_trigger_external_interrupt();
-      /* read mcycle */
-      M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
-      /* enable interrupts */
-      M_SET_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
-      /* verify we got the interrupt */
-      if (loc_vec_cnt + 1 == vect_count)
-      {
-          loc_vec_cnt++;
-          /* number of cycles in vector mode */
-          g_num_of_cycles_vect -= (g_num_of_cycles_start /* + cycles_overhead*/);
-          /* total cycles in vector mode */
-          vect_total += g_num_of_cycles_vect;
-      }
+  /* disable interrupts */
+  bsp_disable_interrupts();
 
-      /*
-       * measure number of cpu cycles in trap mode
-       */
-      /* disable interrupts */
-      M_CLEAR_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
-      /* init mtvec - trap mode */
-      M_WRITE_CSR(mtvec, psp_trap_handler);
-      /* trigger a specific external interrupt */
-      bsp_trigger_external_interrupt();
-      /* read mcycle */
-      M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
-      /* enable interrupts */
-      M_SET_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
-      /* verify we got the interrupt */
-      if (loc_trp_cnt + 1 == trap_count)
-      {
-          loc_trp_cnt++;
-          /* number of cycles in trap mode */
-          g_num_of_cycles_trap -= (g_num_of_cycles_start /* + cycles_overhead*/);
-          /* total cycles in trap mode */
-          trap_total += g_num_of_cycles_trap;
-      }
+  /* measure cycles overhead */
+  if (measure_overhead_cycles_trigger_ext_int(rpt))
+  {
+    /* fail to measure cycles overhead */
+    return 1;
   }
 
-  if (trap_count == D_LOOP_COUNT && vect_count == D_LOOP_COUNT)
-  {
-    trap_total /= D_LOOP_COUNT;
-    vect_total /= D_LOOP_COUNT;
-  }
-  else
-  {
-    trap_total /= loc_trp_cnt;
-    vect_total /= loc_vec_cnt;
-  }
+  /* enable interrupts */
+  bsp_enable_interrupts();
+
+  /*
+   * measure from interrupt trigger to trap/vector entry
+   */
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_vect_count = 0;
+
+  /* measure number of cycles from interrupt to vector start */
+  cycles_to_vect_entry = measure_int_latency(rpt, &g_vect_count, (void*)psp_vect_table,
+                                 1, &g_num_of_cycles);
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_trap_count = 0;
+
+  /* measure number of cycles from interrupt to trap start */
+  cycles_to_trap_entry = measure_int_latency(rpt, &g_trap_count, (void*)psp_trap_handler,
+                                  0, &g_num_of_cycles);
+
+  /*
+   * measure from interrupt trigger to isr entry
+   */
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_vect_count = 0;
+
+  /* measure number of cycles from interrupt to isr via vector */
+  cycles_to_isr_vect_mode = measure_int_latency(rpt, &g_vect_count, (void*)psp_vect_table_pure,
+                                  1, &g_num_of_cycles_isr_entry);
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_trap_count = 0;
+
+  /* measure number of cycles from interrupt to isr via trap */
+  cycles_to_isr_trap_mode = measure_int_latency(rpt, &g_trap_count, (void*)psp_trap_handler_pure,
+                                  0, &g_num_of_cycles_isr_entry);
 
   return 0;
 }
+```
 
+## Measurement function
 ```
-## Trap mode
-### Trap handler
-```
-psp_trap_handler:
-    /* read mcycle csr */
-    csrr    t6,mcycle
-    csrr    t5,mcycleh
-    la      t4, g_num_of_cycles_trap
-    sw      t6,0(t4)
-    sw      t5,4(t4)
-    /* save regs */
-    M_PSP_PUSH
-    csrr    t0, mcause
-    bge     t0, zero, psp_reserved_int
-    li      t1, 11
-    and     t0, t0, t1
-    bne     t0, t1, psp_reserved_int
-    /* call external interrupt handler */
-    jal     interrupt_handler_from_trap
-    /* restore regs */
-    M_PSP_POP
-    mret
-```
-### Interrupt handler
-```
-void
-interrupt_handler_from_trap(void)
+unsigned int
+measure_int_latency(int rpt, unsigned int* p_int_count, void* p_ints_handler,
+                    unsigned int is_vector, volatile cycles_t* p_measure_end)
 {
-  /* count number of interrupts in trap mode */
-  trap_count++;
-  /* clear interrupt indication */
-  bsp_clear_external_interrupt_indication();
-}
-```
-## Vector mode 
-### Vector table
-```
-psp_vect_table:
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    j psp_reserved_int
-    .align 2
-    /* read mcycle csr */
-    csrr    t6,mcycle
-    csrr    t5,mcycleh
-    la      t4, g_num_of_cycles_vect
-    sw      t6,0(t4)
-    sw      t5,4(t4)
-    /* call external interrupt handler */
-    j interrupt_handler_from_vect
-```
-### Interrupt handler
-```
-__attribute__ ((interrupt))
-void
-interrupt_handler_from_vect(void)
-{
-  /* count number of interrupts in vector mode */
-  vect_count++;
-  /* clear interrupt indication */
-  bsp_clear_external_interrupt_indication();
+    int loop_count;
+
+    /* set interrupt trap/vector */
+    bsp_set_interrupts_handler(p_ints_handler, is_vector);
+
+    /*
+     * measure number of cpu cycles in trap/vector mode
+     */
+    for (loop_count = 0 ; loop_count < rpt ; loop_count++)
+    {
+        /* read mcycle */
+        M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
+        /* trigger a specific external interrupt */
+        bsp_trigger_external_interrupt();
+        /* number of cycles in trap mode */
+        *p_measure_end -= (g_num_of_cycles_start + g_cycles_overhead);
+    }
+
+    if (*p_int_count == rpt)
+    {
+        return *p_measure_end;
+    }
+
+    return 0;
 }
 ```

--- a/irq_latency/source/bsp-rv-swerv-olof-eh1.c
+++ b/irq_latency/source/bsp-rv-swerv-olof-eh1.c
@@ -1,0 +1,93 @@
+#include "int-latency.h"
+
+#define D_EXT_INT_IRQ3         3
+#define D_PIC_MEIPL_ADDR       0xF00C0000
+#define D_PIC_MEIE_ADDR        0xF00C2000
+#define D_PIC_MPICCFG_ADDR     0xF00C3000
+#define D_PIC_MEIGWCTRL_ADDR   0xF00C4000
+#define D_PIC_MEIGWCLR_ADDR    0xF00C5000
+#define D_TRIGGER_EXT_INT_ADDR 0x8000100B
+#define D_CSR_MEIPT            0xBC9
+#define D_CSR_MEICIDPL         0xBCB
+#define D_CSR_MEICURPL         0xBCC
+#define M_WRITE_REGISTER_32(reg, value)  ((*(volatile unsigned int *)(void*)(reg)) = (value))
+#define M_WRITE_REGISTER_08(reg, value)  ((*(volatile unsigned char *)(void*)(reg)) = (value))
+#define D_MSTATUS_MIE_MASK     0x00000008
+#define D_MIE_MEIE_MASK        0x00000800
+
+#define _WRITE_CSR_(reg, val) ({ \
+  if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
+    asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
+  else \
+    asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
+#define _WRITE_CSR_INTERMEDIATE_(reg, val) _WRITE_CSR_(reg, val)
+#define M_WRITE_CSR(csr, val)   _WRITE_CSR_INTERMEDIATE_(csr, val)
+
+#define M_CLEAR_CSR_BITS(reg, bits) ({\
+  if (__builtin_constant_p(bits) && (unsigned long)(bits) < 32) \
+    asm volatile ("csrc " #reg ", %0" :: "i"(bits)); \
+  else \
+    asm volatile ("csrc " #reg ", %0" :: "r"(bits)); })
+
+#define M_SET_CSR_BITS(reg, bits) ({\
+    if (__builtin_constant_p(bits) && (unsigned long)(bits) < 32) \
+      asm volatile ("csrs " #reg ", %0" :: "i"(bits)); \
+    else \
+      asm volatile ("csrs " #reg ", %0" :: "r"(bits)); })
+
+
+void bsp_enble_external_interrupt(void)
+{
+  M_WRITE_REGISTER_32(D_PIC_MPICCFG_ADDR, 0);
+  M_WRITE_CSR(D_CSR_MEIPT, 0);
+  M_WRITE_CSR(D_CSR_MEICIDPL, 0);
+  M_WRITE_CSR(D_CSR_MEICURPL, 0);
+  M_WRITE_REGISTER_32(D_PIC_MEIGWCTRL_ADDR + (D_EXT_INT_IRQ3*4), 0);
+  M_WRITE_REGISTER_32(D_PIC_MEIGWCLR_ADDR + (D_EXT_INT_IRQ3*4), 0);
+  M_WRITE_REGISTER_32(D_PIC_MEIPL_ADDR + (D_EXT_INT_IRQ3*4), 15);
+  M_WRITE_REGISTER_32(D_PIC_MEIE_ADDR + (D_EXT_INT_IRQ3*4), 1);
+  M_SET_CSR_BITS(mie, D_MIE_MEIE_MASK);
+}
+
+void bsp_trigger_external_interrupt(void)
+{
+  M_WRITE_REGISTER_08(D_TRIGGER_EXT_INT_ADDR, (1 << D_EXT_INT_IRQ3));
+  asm volatile("fence");
+}
+
+volatile cycles_t cycles;
+
+void bsp_trigger_external_interrupt_measure_cycles(volatile cycles_t* p_cycles)
+{
+  M_WRITE_REGISTER_08(D_TRIGGER_EXT_INT_ADDR, (1 << D_EXT_INT_IRQ3));
+  M_READ_CYCLE_COUNTER_CSR_END(cycles);
+  asm volatile("fence");
+
+  *p_cycles = cycles + 9;
+}
+
+void bsp_clear_external_interrupt_indication(void)
+{
+  M_WRITE_REGISTER_32(D_TRIGGER_EXT_INT_ADDR, 0);
+}
+
+void bsp_set_interrupts_handler(void *p_ints_handler, unsigned int is_vector)
+{
+  unsigned int ints_handler;
+
+  if (is_vector == 0 || is_vector == 1)
+  {
+    ints_handler = ((unsigned int)p_ints_handler) | is_vector;
+    M_WRITE_CSR(mtvec, ints_handler);
+  }
+}
+
+void bsp_enable_interrupts(void)
+{
+  M_SET_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
+}
+
+void bsp_disable_interrupts(void)
+{
+  M_CLEAR_CSR_BITS(mstatus, D_MSTATUS_MIE_MASK);
+}

--- a/irq_latency/source/int-latency.c
+++ b/irq_latency/source/int-latency.c
@@ -1,0 +1,197 @@
+
+#include "int-latency.h"
+
+extern void bsp_init(void);
+extern void psp_vect_table(void);
+extern void psp_trap_handler(void);
+extern void psp_vect_table_pure(void);
+extern void psp_trap_handler_pure(void);
+
+extern void bsp_enable_interrupts(void);
+extern void bsp_disable_interrupts(void);
+extern void bsp_enble_external_interrupt(void);
+extern void bsp_trigger_external_interrupt(void);
+extern void bsp_clear_external_interrupt_indication(void);
+extern void bsp_trigger_external_interrupt_measure_cycles(volatile cycles_t* p_cycles);
+extern void bsp_set_interrupts_handler(void *p_ints_handler, unsigned int is_vector);
+
+volatile unsigned int cycles_to_vect_entry = 0, cycles_to_trap_entry = 0;
+volatile unsigned int cycles_to_isr_vect_mode = 0, cycles_to_isr_trap_mode = 0;
+volatile cycles_t g_cycles_overhead;
+volatile cycles_t g_num_of_cycles_isr_entry, g_num_of_cycles;
+static volatile cycles_t g_num_of_cycles_start;
+unsigned int g_trap_count, g_vect_count;
+
+#define D_LOOP_COUNT           256
+
+__attribute__ ((interrupt))
+void
+interrupt_handler_from_vect(void)
+{
+  /* read mcycle and mcycleh */
+  M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_isr_entry);
+  /* count number of interrupts in vector mode */
+  g_vect_count++;
+  /* clear interrupt indication */
+  bsp_clear_external_interrupt_indication();
+}
+
+void
+interrupt_handler_from_trap(void)
+{
+  /* read mcycle and mcycleh */
+  M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_isr_entry);
+  /* count number of interrupts in trap mode */
+  g_trap_count++;
+  /* clear interrupt indication */
+  bsp_clear_external_interrupt_indication();
+}
+
+unsigned int
+measure_int_latency(int rpt, unsigned int* p_int_count, void* p_ints_handler,
+                    unsigned int is_vector, volatile cycles_t* p_measure_end)
+{
+    int loop_count;
+
+    /* set interrupt trap/vector */
+    bsp_set_interrupts_handler(p_ints_handler, is_vector);
+
+    /*
+     * measure number of cpu cycles in trap/vector mode
+     */
+    for (loop_count = 0 ; loop_count < rpt ; loop_count++)
+    {
+        /* read mcycle */
+        M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
+        /* trigger a specific external interrupt */
+        bsp_trigger_external_interrupt();
+        /* number of cycles in trap mode */
+        *p_measure_end -= (g_num_of_cycles_start + g_cycles_overhead);
+    }
+
+    if (*p_int_count == rpt)
+    {
+        return *p_measure_end;
+    }
+
+    return 0;
+}
+
+unsigned int
+measure_overhead_cycles_trigger_ext_int(int rpt)
+{
+    int loop_count;
+
+    /* make the code worm - measure cycles penalty */
+    for (loop_count = 0 ; loop_count < rpt ; loop_count++)
+    {
+        /* read mcycle and mcycleh */
+        M_READ_CYCLE_COUNTER_CSR(g_num_of_cycles_start);
+        /* we want to measure number of cycles for triggering the interrupt */
+        bsp_trigger_external_interrupt_measure_cycles(&g_cycles_overhead);
+        /* make sure measurement is OK */
+        if (g_cycles_overhead <= g_num_of_cycles_start)
+        {
+            return 1;
+        }
+        /* calculate cycles overhead */
+        g_cycles_overhead -= g_num_of_cycles_start;
+        /* clear interrupt indication */
+        bsp_clear_external_interrupt_indication();
+    }
+
+    return 0;
+}
+
+int
+verify_benchmark (int res __attribute ((unused)))
+{
+  return 0;
+}
+
+
+void
+initialise_benchmark (void)
+{
+}
+
+
+static int benchmark_body (int  rpt);
+
+void
+warm_caches (int  heat)
+{
+  benchmark_body (heat);
+
+  return;
+}
+
+int
+benchmark (void)
+{
+  return benchmark_body (D_LOOP_COUNT);
+}
+
+static int __attribute__ ((noinline))
+benchmark_body (int rpt)
+{
+  /* initialize and enable a specific external interrupt */
+  bsp_enble_external_interrupt();
+
+  /* disable interrupts */
+  bsp_disable_interrupts();
+
+  /* measure cycles overhead */
+  if (measure_overhead_cycles_trigger_ext_int(rpt))
+  {
+    /* fail to measure cycles overhead */
+    return 1;
+  }
+
+  /* enable interrupts */
+  bsp_enable_interrupts();
+
+  /*
+   * measure from interrupt trigger to trap/vector entry
+   */
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_vect_count = 0;
+
+  /* measure number of cycles from interrupt to vector start */
+  cycles_to_vect_entry = measure_int_latency(rpt, &g_vect_count, (void*)psp_vect_table,
+                                 1, &g_num_of_cycles);
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_trap_count = 0;
+
+  /* measure number of cycles from interrupt to trap start */
+  cycles_to_trap_entry = measure_int_latency(rpt, &g_trap_count, (void*)psp_trap_handler,
+                                  0, &g_num_of_cycles);
+
+  /*
+   * measure from interrupt trigger to isr entry
+   */
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_vect_count = 0;
+
+  /* measure number of cycles from interrupt to isr via vector */
+  cycles_to_isr_vect_mode = measure_int_latency(rpt, &g_vect_count, (void*)psp_vect_table_pure,
+                                  1, &g_num_of_cycles_isr_entry);
+
+  /* initialize interrupt counter - how many interrupts occurred */
+  g_trap_count = 0;
+
+  /* measure number of cycles from interrupt to isr via trap */
+  cycles_to_isr_trap_mode = measure_int_latency(rpt, &g_trap_count, (void*)psp_trap_handler_pure,
+                                  0, &g_num_of_cycles_isr_entry);
+
+  return 0;
+}
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/irq_latency/source/int-latency.h
+++ b/irq_latency/source/int-latency.h
@@ -1,0 +1,38 @@
+#ifndef __INT_LATENCY_H__
+#define __INT_LATENCY_H__
+
+#ifdef D_64_BIT_CYCLES
+    typedef unsigned long long cycles_t;
+    #ifdef D_CYCLES
+    #define M_READ_CYCLE_COUNTER_CSR(var) asm volatile ("la t4, " #var : ); \
+                                          asm volatile ("csrr t5, mcycleh" : ); \
+                                          asm volatile ("csrr t6, mcycle" :); \
+                                          asm volatile ("sw t6, 0(t4)"); \
+                                          asm volatile ("sw t5, 4(t4)");
+    #define M_READ_CYCLE_COUNTER_CSR_END(var) asm volatile ("csrr t6, mcycle" : ); \
+                                          asm volatile ("csrr t5, mcycleh" :); \
+                                          asm volatile ("la t4, " #var : ); \
+                                          asm volatile ("sw t6, 0(t4)"); \
+                                          asm volatile ("sw t5, 4(t4)");
+    #else
+    #define M_READ_CYCLE_COUNTER_CSR(var) asm volatile ("la t4, " #var : ); \
+                                          asm volatile ("csrr t5, minstreth" :); \
+                                          asm volatile ("csrr t6, minstret" : ); \
+                                          asm volatile ("sw t6, 0(t4)"); \
+                                          asm volatile ("sw t5, 4(t4)");
+    #define M_READ_CYCLE_COUNTER_CSR_END(var) asm volatile ("csrr t6, minstret" : ); \
+                                          asm volatile ("csrr t5, minstreth" :); \
+                                          asm volatile ("la t4, " #var : ); \
+                                          asm volatile ("sw t6, 0(t4)"); \
+                                          asm volatile ("sw t5, 4(t4)");
+    #endif
+#else
+    typedef unsigned int cycles_t;
+    #ifdef D_CYCLES
+    #define M_READ_CYCLE_COUNTER_CSR(var) asm volatile ("csrr %0, mcycle" : "=r"(var));
+    #else
+    #define M_READ_CYCLE_COUNTER_CSR(var) asm volatile ("csrr %0, minstret" : "=r"(var));
+    #endif
+#endif
+
+#endif /* __INT_LATENCY_H__ */

--- a/irq_latency/source/psp-int-rv.S
+++ b/irq_latency/source/psp-int-rv.S
@@ -1,0 +1,171 @@
+.equ REGBYTES, 4
+.macro M_PSP_PUSH
+  addi    sp,sp,-64
+  sw  ra,60(sp)
+  sw  t0,56(sp)
+  sw  t1,52(sp)
+  sw  t2,48(sp)
+  sw  a0,44(sp)
+  sw  a1,40(sp)
+  sw  a2,36(sp)
+  sw  a3,32(sp)
+  sw  a4,28(sp)
+  sw  a5,24(sp)
+  sw  a6,20(sp)
+  sw  a7,16(sp)
+  sw  t3,12(sp)
+  sw  t4,8(sp)
+  sw  t5,4(sp)
+  sw  t6,0(sp)
+.endm
+
+.macro M_PSP_POP
+ lw  ra,60(sp)
+ lw  t0,56(sp)
+ lw  t1,52(sp)
+ lw  t2,48(sp)
+ lw  a0,44(sp)
+ lw  a1,40(sp)
+ lw  a2,36(sp)
+ lw  a3,32(sp)
+ lw  a4,28(sp)
+ lw  a5,24(sp)
+ lw  a6,20(sp)
+ lw  a7,16(sp)
+ lw  t3,12(sp)
+ lw  t4,8(sp)
+ lw  t5,4(sp)
+ lw  t6,0(sp)
+ addi    sp,sp,64
+.endm
+
+#ifdef D_64_BIT_CYCLES
+    #ifdef D_CYCLES
+        .macro M_READ_CYCLES var
+            csrr    t6,mcycle
+            csrr    t5,mcycleh
+            la      t4, \var
+            sw      t6,0(t4)
+            sw      t5,4(t4)
+        .endm
+    #else
+        .macro M_READ_CYCLES var
+            csrr    t6,minstret
+            csrr    t5,minstreth
+            la      t4, \var
+            sw      t6,0(t4)
+            sw      t5,4(t4)
+        .endm
+    #endif
+    #else
+    #ifdef D_CYCLES
+        .macro M_READ_CYCLES var
+            csrr    t6,mcycle
+            la      t5, \var
+            sw      t6,0(t5)
+        .endm
+    #else
+        .macro M_READ_CYCLES var
+            csrr    t6,minstret
+            la      t5, \var
+            sw      t6,0(t5)
+        .endm
+    #endif
+#endif
+.section  .text
+.global psp_vect_table
+.global psp_trap_handler
+.global psp_vect_table_pure
+.global psp_trap_handler_pure
+.extern g_num_of_cycles
+
+.align 4
+psp_trap_handler:
+    /* read mcycle csr */
+    M_READ_CYCLES g_num_of_cycles
+    /* save regs */
+    M_PSP_PUSH
+    csrr    t0, mcause
+    li      t1, 11
+    and     t0, t0, t1
+    bne     t0, t1, psp_reserved_int
+    /* call external interrupt handler */
+    jal     interrupt_handler_from_trap
+    /* restore regs */
+    M_PSP_POP
+    mret
+
+.align 4
+psp_trap_handler_pure:
+    /* save regs */
+    M_PSP_PUSH
+    csrr    t0, mcause
+    li      t1, 11
+    and     t0, t0, t1
+    bne     t0, t1, psp_reserved_int
+    /* call external interrupt handler */
+    jal     interrupt_handler_from_trap
+    /* restore regs */
+    M_PSP_POP
+    mret
+
+.align 4
+psp_vect_table:
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    M_READ_CYCLES g_num_of_cycles
+    /* call external interrupt handler */
+    j interrupt_handler_from_vect
+
+.align 4
+psp_vect_table_pure:
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    j psp_reserved_int
+    .align 2
+    /* call external interrupt handler */
+    j interrupt_handler_from_vect
+
+psp_reserved_int:
+1:
+    nop
+    nop
+    j 1b


### PR DESCRIPTION
The base design was changed; initially, I measured cycles while interrupts were disabled -> trigger the external interrupt -> reenable the interrupt. Now, I measure while interrupts are always enabled so cycles also include any pipe flush as a result of the interrupt.
C code was added as well which includes:
source/int-latency.c : measure the interrupt latency (common code) 
source/int-latency.h
source/psp-int-rv.S : interrupt vector/trap (common code)
source/bsp-rv-swerv-olof-eh1.c : bsp specific file; other platforms should duplicate and implement the same interface

The code measures interrupt latency for the following cases
- measure from interrupt trigger -> vector entry
- measure from interrupt trigger -> trap entry
- measure from interrupt trigger -> ISR entry (in vector mode)
- measure from interrupt trigger -> ISR entry (in trap mode)
